### PR TITLE
Add generate Vapid Keys script for alert service

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index.js",
-	"docker:server:build": "docker-compose build",
-	"docker:server:up": "docker-compose up -d"
+    "generateVapidKeys": "node scripts/web-push/generateVapidKeys",
+    "docker:server:build": "docker-compose build",
+    "docker:server:up": "docker-compose up -d"
   },
   "repository": {
     "type": "git",

--- a/scripts/web-push/generateVapidKeys.js
+++ b/scripts/web-push/generateVapidKeys.js
@@ -1,3 +1,3 @@
 const webpush = require('web-push');
 const vapidKeys = webpush.generateVAPIDKeys()
-console.log(`privateVapidKey: ${vapidKeys.privateKey},\npublicVapidKey: ${vapidKeys.publicKey}`)
+console.log(`"privateVapidKey": "${vapidKeys.privateKey}",\n"publicVapidKey": "${vapidKeys.publicKey}"`)

--- a/scripts/web-push/generateVapidKeys.js
+++ b/scripts/web-push/generateVapidKeys.js
@@ -1,4 +1,3 @@
 const webpush = require('web-push');
 const vapidKeys = webpush.generateVAPIDKeys()
-console.log(`privateKey: ${vapidKeys.privateKey}`)
-console.log(`publicKey: ${vapidKeys.publicKey}`)
+console.log(`privateVapidKey: ${vapidKeys.privateKey},\npublicVapidKey: ${vapidKeys.publicKey}`)

--- a/scripts/web-push/generateVapidKeys.js
+++ b/scripts/web-push/generateVapidKeys.js
@@ -1,0 +1,4 @@
+const webpush = require('web-push');
+const vapidKeys = webpush.generateVAPIDKeys()
+console.log(`privateKey: ${vapidKeys.privateKey}`)
+console.log(`publicKey: ${vapidKeys.publicKey}`)

--- a/src/services/alert.js
+++ b/src/services/alert.js
@@ -29,8 +29,7 @@ class AlertService extends EventEmitter {
       this.enabled = true
       webPush.setVapidDetails('mailto: contact@aggr.trade', config.publicVapidKey, config.privateVapidKey)
     }
-
-    console.log(`[alert] service is ${this.enabled ? 'enabled': 'disabled, run \`npm run generateVapidKeys\` and add them to \`config.json\`'}`)
+    console.log([alert] Service is ${this.enabled ? 'enabled' : 'disabled'}. Please run \npm run generateVapidKeys` and add the generated keys to `config.json`.`)
   }
 
   getRangePrice(n) {

--- a/src/services/alert.js
+++ b/src/services/alert.js
@@ -29,6 +29,7 @@ class AlertService extends EventEmitter {
       this.enabled = true
       webPush.setVapidDetails('mailto: contact@aggr.trade', config.publicVapidKey, config.privateVapidKey)
     }
+    console.log(`[alert] service enabled: ${this.enabled}`)
   }
 
   getRangePrice(n) {

--- a/src/services/alert.js
+++ b/src/services/alert.js
@@ -29,7 +29,8 @@ class AlertService extends EventEmitter {
       this.enabled = true
       webPush.setVapidDetails('mailto: contact@aggr.trade', config.publicVapidKey, config.privateVapidKey)
     }
-    console.log(`[alert] service enabled: ${this.enabled}`)
+
+    console.log(`[alert] service is ${this.enabled ? 'enabled': 'disabled, run \`npm run generateVapidKeys\` and add them to \`config.json\`'}`)
   }
 
   getRangePrice(n) {


### PR DESCRIPTION
To make use of this:
`npm run generateVapidKeys`
copy the output to `config.json`

![image](https://github.com/Tucsky/aggr-server/assets/2179775/6520d52a-5e5e-4014-a381-854fe1463a31)
![image](https://github.com/Tucsky/aggr-server/assets/2179775/514a9904-f173-4134-ab69-4cf33ce71ec9)


