### PR TITLE
chore(docker): add python3 and other deps to builder stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,10 @@
 FROM  node:current-alpine3.18 as builder
 
+RUN apk add --update --no-cache \
+   python3 \
+   make \
+   g++
+
 COPY  package*.json /
 RUN   set ex && npm install --production
 


### PR DESCRIPTION
A user contacted me on the Discord server and was complaining that Docker wouldn't build and was failing at the npm build stage:

```bash
 > [server builder 3/3] RUN   set ex && npm install --production:               
0.460 npm WARN config production Use `--omit=dev` instead.                      
2.259 npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.               
2.261 npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.               
3.084 npm notice 
3.084 npm notice New patch version of npm available! 9.8.0 -> 9.8.1
3.084 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.8.1>
3.084 npm notice Run `npm install -g npm@9.8.1` to update!
3.084 npm notice 
3.085 npm ERR! code 1
3.089 npm ERR! path /node_modules/bufferutil
3.090 npm ERR! command failed
3.090 npm ERR! command sh -c node-gyp-build
3.090 npm ERR! gyp info it worked if it ends with ok
3.090 npm ERR! gyp info using node-gyp@9.4.0
3.090 npm ERR! gyp info using node@20.5.1 | linux | arm64
3.090 npm ERR! gyp ERR! find Python 
3.090 npm ERR! gyp ERR! find Python Python is not set from command line or npm configuration
3.090 npm ERR! gyp ERR! find Python Python is not set from environment variable PYTHON
3.091 npm ERR! gyp ERR! find Python checking if "python3" can be used
3.091 npm ERR! gyp ERR! find Python - "python3" is not in PATH or produced an error
3.091 npm ERR! gyp ERR! find Python checking if "python" can be used
3.091 npm ERR! gyp ERR! find Python - "python" is not in PATH or produced an error
3.091 npm ERR! gyp ERR! find Python 
3.091 npm ERR! gyp ERR! find Python **********************************************************
3.091 npm ERR! gyp ERR! find Python You need to install the latest version of Python.
3.091 npm ERR! gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
3.091 npm ERR! gyp ERR! find Python you can try one of the following options:
3.091 npm ERR! gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
3.091 npm ERR! gyp ERR! find Python   (accepted by both node-gyp and npm)
3.091 npm ERR! gyp ERR! find Python - Set the environment variable PYTHON
3.091 npm ERR! gyp ERR! find Python - Set the npm configuration variable python:
3.091 npm ERR! gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
3.091 npm ERR! gyp ERR! find Python For more information consult the documentation at:
3.091 npm ERR! gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
3.091 npm ERR! gyp ERR! find Python **********************************************************
3.091 npm ERR! gyp ERR! find Python 
3.091 npm ERR! gyp ERR! configure error 
3.091 npm ERR! gyp ERR! stack Error: Could not find any Python installation to use
3.091 npm ERR! gyp ERR! stack     at PythonFinder.fail (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:330:47)
3.091 npm ERR! gyp ERR! stack     at PythonFinder.runChecks (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:159:21)
3.091 npm ERR! gyp ERR! stack     at PythonFinder.<anonymous> (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:202:16)
3.091 npm ERR! gyp ERR! stack     at PythonFinder.execFileCallback (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:294:16)
3.091 npm ERR! gyp ERR! stack     at exithandler (node:child_process:429:5)
3.091 npm ERR! gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:441:5)
3.091 npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:514:28)
3.091 npm ERR! gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:292:12)
3.091 npm ERR! gyp ERR! stack     at onErrorNT (node:internal/child_process:484:16)
3.091 npm ERR! gyp ERR! stack     at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
3.091 npm ERR! gyp ERR! System Linux 5.15.49-linuxkit-pr
3.091 npm ERR! gyp ERR! command "/usr/local/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
3.091 npm ERR! gyp ERR! cwd /node_modules/bufferutil
3.091 npm ERR! gyp ERR! node -v v20.5.1
3.091 npm ERR! gyp ERR! node-gyp -v v9.4.0
3.091 npm ERR! gyp ERR! not ok
3.093 
3.093 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-08-27T15_14_47_584Z-debug-0.log
------
failed to solve: process "/bin/sh -c set ex && npm install --production" did not complete successfully: exit code: 1
```

The solution is to install python3 and related dependencies to the node alpine image in builder stage. See commit.