### PR TITLE
feat: add Hyperliquid exchange

### DIFF
--- a/src/exchanges/hyperliquid.js
+++ b/src/exchanges/hyperliquid.js
@@ -1,0 +1,153 @@
+const Exchange = require('../exchange')
+const { readProducts, saveProducts } = require('../services/catalog')
+const axios = require('axios')
+
+class Hyperliquid extends Exchange {
+  constructor() {
+    super()
+    this.id = 'HYPERLIQUID'
+
+    this.endpoints = {
+      PRODUCTS: 'https://api.hyperliquid.xyz/info'
+    }
+  }
+
+  async getUrl() {
+    return 'wss://api.hyperliquid.xyz/ws'
+  }
+
+  // Custom getProducts implementation for POST API
+  async getProducts(forceRefreshProducts = false) {
+    let formatedProducts
+
+    // Load from cache if not forcing refresh
+    if (!forceRefreshProducts) {
+      try {
+        formatedProducts = await readProducts(this.id)
+      } catch (error) {
+        console.error(`[${this.id}/getProducts] failed to read products`, error)
+      }
+    }
+
+    // Fetch new products if no cache available
+    if (!formatedProducts) {
+      try {
+        console.log(`[${this.id}] fetching products via POST API`)
+
+        const response = await axios.post(
+          this.endpoints.PRODUCTS,
+          { type: 'meta' },
+          {
+            headers: { 'Content-Type': 'application/json' }
+          }
+        )
+
+        formatedProducts = this.formatProducts(response.data) || []
+
+        // Save to cache
+        await saveProducts(this.id, formatedProducts)
+        console.log(
+          `[${this.id}] saved ${
+            formatedProducts.products?.length || 0
+          } products`
+        )
+      } catch (error) {
+        console.error(
+          `[${this.id}/getProducts] failed to fetch products`,
+          error.message
+        )
+        throw error
+      }
+    }
+
+    // Set products to instance
+    if (formatedProducts && formatedProducts.products) {
+      this.products = formatedProducts.products
+    }
+
+    return this.products
+  }
+
+  formatProducts(response) {
+    const products = []
+
+    if (response && response.universe && response.universe.length) {
+      for (const product of response.universe) {
+        products.push(product.name)
+      }
+    }
+
+    console.log(`[${this.id}] formatted ${products.length} products`)
+    return { products }
+  }
+
+  /**
+   * Sub
+   * @param {WebSocket} api
+   * @param {string} pair
+   */
+  async subscribe(api, pair) {
+    if (!(await super.subscribe.apply(this, arguments))) {
+      return
+    }
+
+    api.send(
+      JSON.stringify({
+        method: 'subscribe',
+        subscription: {
+          type: 'trades',
+          coin: pair
+        }
+      })
+    )
+
+    return true
+  }
+
+  /**
+   * Sub
+   * @param {WebSocket} api
+   * @param {string} pair
+   */
+  async unsubscribe(api, pair) {
+    if (!(await super.unsubscribe.apply(this, arguments))) {
+      return
+    }
+
+    api.send(
+      JSON.stringify({
+        method: 'unsubscribe',
+        subscription: {
+          type: 'trades',
+          coin: pair
+        }
+      })
+    )
+
+    return true
+  }
+
+  onMessage(event, api) {
+    const json = JSON.parse(event.data)
+
+    if (json && json.channel === 'trades') {
+      return this.emitTrades(
+        api.id,
+        json.data.map(trade => this.formatTrade(trade))
+      )
+    }
+  }
+
+  formatTrade(trade) {
+    return {
+      exchange: this.id,
+      pair: trade.coin,
+      timestamp: +new Date(trade.time),
+      price: +trade.px,
+      size: +trade.sz,
+      side: trade.side === 'B' ? 'buy' : 'sell'
+    }
+  }
+}
+
+module.exports = Hyperliquid

--- a/src/services/catalog.js
+++ b/src/services/catalog.js
@@ -244,7 +244,7 @@ module.exports.parseMarket = function (exchangeId, symbol, noStable = true) {
   } else if (exchangeId === 'KUCOIN') {
     localSymbol = localSymbol.replace(/M$/, '')
   } else if (exchangeId === 'HYPERLIQUID') {
-    localSymbol += 'USDC'
+    localSymbol = localSymbol.replace(/^k/, '') + 'USD'
   }
 
   localSymbol = localSymbol

--- a/src/services/catalog.js
+++ b/src/services/catalog.js
@@ -2,7 +2,6 @@ const axios = require('axios')
 const fs = require('fs')
 const { ensureDirectoryExists } = require('../helper')
 
-
 const stablecoins = [
   'USDT',
   'USDC',
@@ -181,7 +180,11 @@ module.exports.parseMarket = function (exchangeId, symbol, noStable = true) {
 
   if (/[HUZ_-]\d{2}/.test(symbol)) {
     type = 'future'
-  } else if (exchangeId === 'BINANCE_FUTURES' || exchangeId === 'DYDX') {
+  } else if (
+    exchangeId === 'BINANCE_FUTURES' ||
+    exchangeId === 'DYDX' ||
+    exchangeId === 'HYPERLIQUID'
+  ) {
     type = 'perp'
   } else if (exchangeId === 'BITFINEX' && /F0$/.test(symbol)) {
     type = 'perp'
@@ -240,6 +243,8 @@ module.exports.parseMarket = function (exchangeId, symbol, noStable = true) {
       .replace(/_.*/, '')
   } else if (exchangeId === 'KUCOIN') {
     localSymbol = localSymbol.replace(/M$/, '')
+  } else if (exchangeId === 'HYPERLIQUID') {
+    localSymbol += 'USDC'
   }
 
   localSymbol = localSymbol


### PR DESCRIPTION
# feat: Add Hyperliquid exchange support

## Summary
Adds Hyperliquid perpetual futures exchange with custom POST-based product discovery and real-time trade collection.

## Implementation Details

### 🔧 **Custom Implementation**
- **File**: `src/exchanges/hyperliquid.js`
- **Products API**: Overridden `getProducts()` for POST endpoint (`{"type": "meta"}`)
- **WebSocket**: Standard implementation (`wss://api.hyperliquid.xyz/ws`)

### ⚠️ **Key Limitation**
- **No Historical Recovery**: `getMissingTrades()` not implemented 
- **No Trade Data Available**: Neither REST API nor S3 archive provide historical trades
- **S3 Archive**: Only L2 book snapshots and blockchain data (no trade history)
- **Reference**: https://hyperliquid.gitbook.io/hyperliquid-docs/historical-data

## Technical Notes

**Custom Products Fetch**:
```javascript
// Bypasses catalog.js fetchProducts() due to POST requirement
axios.post('https://api.hyperliquid.xyz/info', { type: 'meta' })
```

**Trade Message Format**:
```javascript
{
  "channel": "trades",
  "data": [{
    "coin": "BTC", 
    "side": "B",           // "B"=Buy, "A"=Ask/Sell
    "px": "109183.0",      // String format
    "sz": "0.00011",       // String format
    "time": 1748327839460  // Unix ms
  }]
}
```

## Checked
- [x] Custom POST products discovery
- [x] WebSocket trades subscription  
- [x] Real-time data to InfluxDB
- [x] API endpoints integration
- [ ] ~~Historical recovery~~ (No data source available)
